### PR TITLE
ci: publish a mutable :latest image tag from the default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
+            # Mutable :latest tracks the default branch so consumers (the Omnia
+            # operator's built-in DefaultLangChainImage) can pin a stable name.
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## What
Publish a mutable `:latest` image tag on default-branch pushes.

## Why
The image currently publishes `:main`, `:sha-…`, and `:vX.Y.Z` (on tags), but **never `:latest`**. The Omnia operator's built-in fallback (`DefaultLangChainImage`) and the chart's `framework.images.langchain` default reference `ghcr.io/altairalabs/omnia-langchain-runtime:latest`. With no `:latest` published, a `framework.type: langchain` AgentRuntime fails with `ErrImagePull: …:latest: not found` unless the image is overridden per-deploy.

Verified on a live cluster: pinning the agent to the existing `:main` tag, the langchain runtime pulls and the agent goes fully Ready — so the runtime is fine; the only gap was the missing stable tag.

## Change
Add `type=raw,value=latest,enable={{is_default_branch}}` to the metadata-action tags, so `:latest` tracks `main` (only on default-branch pushes — PRs and feature branches don't clobber it).
