### PR TITLE
feat: honor provider params, fix LangGraph 0.2 prompt API, track tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install grpcio-tools and ruff
-        run: pip install grpcio-tools ruff
+        # Pin the codegen toolchain: unpinned, grpcio-tools/ruff drift and the
+        # generated *_pb2*.py files no longer match the committed copies, failing
+        # the drift check on every PR regardless of content. Bump deliberately.
+        run: pip install grpcio-tools==1.80.0 ruff==0.15.16
 
       - name: Generate protobuf files
         run: make proto

--- a/src/omnia_langchain_runtime/agent.py
+++ b/src/omnia_langchain_runtime/agent.py
@@ -40,11 +40,11 @@ def create_agent(
     Returns:
         Compiled LangGraph agent.
     """
-    prompt = pack.get_prompt(prompt_name)
-    if prompt is None:
+    prompt_config = pack.get_prompt(prompt_name)
+    if prompt_config is None:
         raise ValueError(f"Prompt '{prompt_name}' not found in pack")
 
-    # Get system prompt
+    # Get system prompt from template
     template = PromptPackTemplate.from_promptpack(pack, prompt_name, model_name=model_name)
 
     # Apply LLM parameters
@@ -52,11 +52,15 @@ def create_agent(
     if params:
         llm = _apply_params(llm, params)
 
-    # Create the agent
+    # Format the system prompt (with empty variables for now - will be populated at runtime)
+    system_prompt = template.format()
+
+    # Create the agent with system prompt
+    # LangGraph 0.2+ uses 'prompt' parameter for system message
     agent = create_react_agent(
         llm,
         tools=list(tools),
-        state_modifier=_create_state_modifier(template),
+        prompt=system_prompt,
     )
 
     logger.info(
@@ -71,28 +75,23 @@ def create_agent(
 def _apply_params(llm: BaseChatModel, params: dict[str, Any]) -> BaseChatModel:  # type: ignore[return-value]
     """Apply parameters to an LLM.
 
+    Note: LLM parameters like temperature, max_tokens, top_p should be configured
+    at provider creation time (via Provider CRD), not at runtime via bind().
+    The bind() method doesn't work consistently across providers (especially Ollama).
+
     Args:
         llm: Language model.
         params: Parameters to apply.
 
     Returns:
-        LLM with parameters applied.
+        LLM (unchanged - params are applied at provider creation).
     """
-    # Most LangChain models support bind() for runtime config
-    bind_params = {}
-
-    if "temperature" in params:
-        bind_params["temperature"] = params["temperature"]
-    if "max_tokens" in params:
-        bind_params["max_tokens"] = params["max_tokens"]
-    if "top_p" in params:
-        bind_params["top_p"] = params["top_p"]
-
-    if bind_params:
-        try:
-            return llm.bind(**bind_params)  # type: ignore[return-value]
-        except Exception as e:
-            logger.warning("Failed to bind params to LLM: %s", e)
+    # Skip runtime param binding - it doesn't work reliably across providers
+    # Temperature and other params should be set via Provider CRD -> providers.py
+    if params:
+        logger.debug(
+            "Skipping runtime params (should be set at provider creation): %s", list(params.keys())
+        )
 
     return llm
 

--- a/src/omnia_langchain_runtime/config.py
+++ b/src/omnia_langchain_runtime/config.py
@@ -61,6 +61,9 @@ class Config:
     provider_base_url: str = ""
     provider_ref_name: str = ""
     provider_ref_namespace: str = ""
+    provider_temperature: float | None = None
+    provider_max_tokens: int | None = None
+    provider_top_p: float | None = None
 
     # Context management
     context_window: int = 0  # 0 = no limit
@@ -103,7 +106,7 @@ def load_config() -> Config:
         prompt_name=_get_or_default("OMNIA_PROMPT_NAME", "default"),
         session_type=_parse_session_type(os.getenv("OMNIA_SESSION_TYPE", "memory")),
         session_url=os.getenv("OMNIA_SESSION_URL", ""),
-        session_ttl_seconds=_parse_int("OMNIA_SESSION_TTL", 86400),
+        session_ttl_seconds=_parse_duration_seconds("OMNIA_SESSION_TTL", 86400),
         provider_type=_parse_provider_type(os.getenv("OMNIA_PROVIDER_TYPE", "mock")),
         provider_model=os.getenv("OMNIA_PROVIDER_MODEL", ""),
         provider_base_url=os.getenv("OMNIA_PROVIDER_BASE_URL", ""),
@@ -116,9 +119,12 @@ def load_config() -> Config:
             os.getenv("OMNIA_PROVIDER_MOCK_CONFIG", ""),
         ),
         media_base_path=_get_or_default("OMNIA_MEDIA_BASE_PATH", "/etc/omnia/media"),
-        tools_config_path=os.getenv("OMNIA_TOOLS_CONFIG", ""),
+        tools_config_path=os.getenv("OMNIA_TOOLS_CONFIG_PATH", os.getenv("OMNIA_TOOLS_CONFIG", "")),
         grpc_port=_parse_int("OMNIA_GRPC_PORT", 9000),
         health_port=_parse_int("OMNIA_HEALTH_PORT", 9001),
+        provider_temperature=_parse_float("OMNIA_PROVIDER_TEMPERATURE"),
+        provider_max_tokens=_parse_int_optional("OMNIA_PROVIDER_MAX_TOKENS"),
+        provider_top_p=_parse_float("OMNIA_PROVIDER_TOP_P"),
     )
 
     # Load API keys from environment
@@ -156,6 +162,64 @@ def _parse_int(name: str, default: int) -> int:
         return int(value)
     except ValueError as e:
         raise ConfigError(f"Invalid {name}: must be an integer") from e
+
+
+def _parse_int_optional(name: str) -> int | None:
+    """Parse an optional integer environment variable."""
+    value = os.getenv(name)
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError as e:
+        raise ConfigError(f"Invalid {name}: must be an integer") from e
+
+
+def _parse_float(name: str) -> float | None:
+    """Parse an optional float environment variable."""
+    value = os.getenv(name)
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError as e:
+        raise ConfigError(f"Invalid {name}: must be a number") from e
+
+
+def _parse_duration_seconds(name: str, default: int) -> int:
+    """Parse a duration string (e.g., '1h', '30m', '86400') into seconds."""
+    value = os.getenv(name)
+    if not value:
+        return default
+
+    # If it's already an integer, return it
+    try:
+        return int(value)
+    except ValueError:
+        pass
+
+    # Parse duration strings like "1h", "30m", "1h30m"
+    import re
+
+    total_seconds = 0
+    pattern = re.compile(r"(\d+)([hms])")
+    matches = pattern.findall(value.lower())
+
+    if not matches:
+        raise ConfigError(
+            f"Invalid {name}: must be an integer or duration string (e.g., '1h', '30m')"
+        )
+
+    for amount, unit in matches:
+        amount = int(amount)
+        if unit == "h":
+            total_seconds += amount * 3600
+        elif unit == "m":
+            total_seconds += amount * 60
+        elif unit == "s":
+            total_seconds += amount
+
+    return total_seconds
 
 
 def _parse_provider_type(value: str) -> ProviderType:

--- a/src/omnia_langchain_runtime/handler.py
+++ b/src/omnia_langchain_runtime/handler.py
@@ -176,12 +176,29 @@ class LangChainHandler:
                     )
 
                 elif event_type == "on_llm_end":
-                    # Track token usage
+                    # Track token usage from LLM response
                     llm_output: Any = event.get("data", {}).get("output", {})
+
+                    # Try standard LangChain format (OpenAI-style)
                     if hasattr(llm_output, "llm_output") and llm_output.llm_output:
                         usage = llm_output.llm_output.get("token_usage", {})
                         total_input_tokens += usage.get("prompt_tokens", 0)
                         total_output_tokens += usage.get("completion_tokens", 0)
+
+                    # Try Ollama format (in response_metadata)
+                    if hasattr(llm_output, "response_metadata"):
+                        metadata = llm_output.response_metadata or {}
+                        total_input_tokens += metadata.get("prompt_eval_count", 0)
+                        total_output_tokens += metadata.get("eval_count", 0)
+
+                    # Try generations format (some providers)
+                    if hasattr(llm_output, "generations"):
+                        for gen_list in llm_output.generations:
+                            for gen in gen_list:
+                                if hasattr(gen, "generation_info") and gen.generation_info:
+                                    info = gen.generation_info
+                                    total_input_tokens += info.get("prompt_eval_count", 0)
+                                    total_output_tokens += info.get("eval_count", 0)
 
             # Add assistant message to session
             if final_content:
@@ -190,6 +207,13 @@ class LangChainHandler:
             # Save session
             await self.session_store.save(session)
 
+            # Log token usage
+            logger.debug(
+                "Token usage: input=%d, output=%d",
+                total_input_tokens,
+                total_output_tokens,
+            )
+
             # Send done message
             yield runtime_pb2.ServerMessage(
                 done=runtime_pb2.Done(
@@ -197,7 +221,7 @@ class LangChainHandler:
                     usage=runtime_pb2.Usage(
                         input_tokens=total_input_tokens,
                         output_tokens=total_output_tokens,
-                        cost_usd=0.0,  # TODO: Calculate cost
+                        cost_usd=0.0,  # TODO: Calculate cost from provider pricing
                     ),
                 )
             )

--- a/src/omnia_langchain_runtime/providers.py
+++ b/src/omnia_langchain_runtime/providers.py
@@ -79,6 +79,14 @@ def _create_claude_provider(config: Config, **kwargs: Any) -> BaseChatModel:
     if config.provider_base_url:
         provider_kwargs["base_url"] = config.provider_base_url
 
+    # Apply provider parameters from config
+    if config.provider_temperature is not None:
+        provider_kwargs["temperature"] = config.provider_temperature
+    if config.provider_top_p is not None:
+        provider_kwargs["top_p"] = config.provider_top_p
+    if config.provider_max_tokens is not None:
+        provider_kwargs["max_tokens"] = config.provider_max_tokens
+
     return ChatAnthropic(**provider_kwargs)
 
 
@@ -104,6 +112,14 @@ def _create_openai_provider(config: Config, **kwargs: Any) -> BaseChatModel:
     if config.provider_base_url:
         provider_kwargs["base_url"] = config.provider_base_url
 
+    # Apply provider parameters from config
+    if config.provider_temperature is not None:
+        provider_kwargs["temperature"] = config.provider_temperature
+    if config.provider_top_p is not None:
+        provider_kwargs["top_p"] = config.provider_top_p
+    if config.provider_max_tokens is not None:
+        provider_kwargs["max_tokens"] = config.provider_max_tokens
+
     return ChatOpenAI(**provider_kwargs)
 
 
@@ -120,11 +136,21 @@ def _create_gemini_provider(config: Config, **kwargs: Any) -> BaseChatModel:
     model = config.provider_model or "gemini-pro"
     api_key = config.api_keys.get("google")
 
-    return ChatGoogleGenerativeAI(
-        model=model,
-        google_api_key=api_key,
+    provider_kwargs: dict[str, Any] = {
+        "model": model,
+        "google_api_key": api_key,
         **kwargs,
-    )
+    }
+
+    # Apply provider parameters from config
+    if config.provider_temperature is not None:
+        provider_kwargs["temperature"] = config.provider_temperature
+    if config.provider_top_p is not None:
+        provider_kwargs["top_p"] = config.provider_top_p
+    if config.provider_max_tokens is not None:
+        provider_kwargs["max_output_tokens"] = config.provider_max_tokens
+
+    return ChatGoogleGenerativeAI(**provider_kwargs)
 
 
 def _create_ollama_provider(config: Config, **kwargs: Any) -> BaseChatModel:
@@ -140,11 +166,21 @@ def _create_ollama_provider(config: Config, **kwargs: Any) -> BaseChatModel:
     model = config.provider_model or "llama3.2"
     base_url = config.provider_base_url or "http://localhost:11434"
 
-    return ChatOllama(
-        model=model,
-        base_url=base_url,
+    provider_kwargs: dict[str, Any] = {
+        "model": model,
+        "base_url": base_url,
         **kwargs,
-    )
+    }
+
+    # Apply provider parameters from config
+    if config.provider_temperature is not None:
+        provider_kwargs["temperature"] = config.provider_temperature
+    if config.provider_top_p is not None:
+        provider_kwargs["top_p"] = config.provider_top_p
+    if config.provider_max_tokens is not None:
+        provider_kwargs["num_predict"] = config.provider_max_tokens
+
+    return ChatOllama(**provider_kwargs)
 
 
 def _create_mock_provider(config: Config, **kwargs: Any) -> BaseChatModel:

--- a/src/omnia_langchain_runtime/runtime_pb2_grpc.py
+++ b/src/omnia_langchain_runtime/runtime_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 
 from . import runtime_pb2 as runtime__pb2
 
-GRPC_GENERATED_VERSION = "1.76.0"
+GRPC_GENERATED_VERSION = "1.80.0"
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 


### PR DESCRIPTION
## What
Makes the LangChain runtime production-usable under Omnia. Three changes:

1. **LangGraph 0.2+ compatibility (`agent.py`)** — `create_react_agent` now takes `prompt=system_prompt`; the previously-used `state_modifier=` was removed in LangGraph 0.2 and breaks on the first real turn. Also stop applying LLM params via runtime `.bind()` (unreliable across providers, especially Ollama) — params are now set at provider creation.
2. **Provider tuning params (`config.py`, `providers.py`)** — read `OMNIA_PROVIDER_TEMPERATURE` / `OMNIA_PROVIDER_MAX_TOKENS` / `OMNIA_PROVIDER_TOP_P` and apply them per provider (Anthropic/OpenAI/Gemini/Ollama, each with its own kwarg name). `OMNIA_SESSION_TTL` now accepts duration strings (`"1h"`, `"30m"`); `OMNIA_TOOLS_CONFIG` → `OMNIA_TOOLS_CONFIG_PATH` (back-compat fallback kept).
3. **Multi-provider token tracking (`handler.py`)** — pull input/output token counts from OpenAI-style, Ollama (`prompt_eval_count`/`eval_count`), and generations-style responses, for Omnia cost/usage telemetry.

## Why now
Validating Omnia's `framework.type: langchain` support against a live cluster showed the published image passes its gRPC health check but would break on an actual conversation (the `state_modifier` API) and ignored provider params + reported zero tokens. This makes a langchain agent actually work end-to-end in Omnia.

## Also included
A CI fix (cherry-picked): pin `grpcio-tools==1.80.0` + `ruff==0.15.16` in the proto job so the codegen drift check is reproducible (it was failing on every PR as the unpinned toolchain moved past the committed `*_pb2*.py`). Needed for this PR's CI to be green.

## Tested
ruff lint + format, mypy (clean), `pytest` (22 passed) locally.
